### PR TITLE
Fix connection blocking on register / elsewhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.6
+  - Wait till pipeline is in run state to connect. Before this patch this plugin
+    could block logstash indefinitely due to a connect method that never finishes.
+
 ## 3.0.5
   - Fix some documentation issues
 

--- a/logstash-input-stomp.gemspec
+++ b/logstash-input-stomp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-stomp'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from a stomp server"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/stomp_spec.rb
+++ b/spec/inputs/stomp_spec.rb
@@ -2,7 +2,6 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/stomp"
 
 describe LogStash::Inputs::Stomp do
-  let(:klass) { LogStash::Inputs::Stomp }
   let(:host) { "localhost" }
   let(:destination) { "/foo" }
   let(:stomp_settings) {
@@ -11,34 +10,37 @@ describe LogStash::Inputs::Stomp do
       "destination" => destination
     }
   }
-  let(:instance) { klass.new(stomp_settings) }
+  subject(:instance) { described_class.new(stomp_settings) }
+  let(:client) { double("client") }
 
-  context "when connected" do
-    let(:client) { double("client") }
+  before do
+    allow(instance).to receive(:new_client).and_return(client)
+    allow(client).to receive(:on_connection_closed)
+    allow(instance).to receive(:new_client).and_return(client)
+  end
 
-    before do
-      allow(instance).to receive(:new_client).and_return(client)
-      allow(client).to receive(:connect)
-      allow(client).to receive(:connected?).and_return(true)
-      allow(client).to receive(:on_connection_closed)
-    end
-
+  context "when registered" do
     it "should register without error" do
       instance.register
     end
   end
 
-  describe "stopping" do
-    let(:config) { {"host" => "localhost", "destination" => "/foo"} }
-    let(:client) { double("client") }
+  context "connecting and disconnecting" do
     before do
-      allow(subject).to receive(:new_client).and_return(client)
-      allow(subject).to receive(:connect)
       allow(client).to receive(:connect)
       allow(client).to receive(:connected?).and_return(true)
-      allow(client).to receive(:on_connection_closed)
       allow(client).to receive(:subscribe)
+      allow(client).to receive(:disconnect)
     end
-    it_behaves_like "an interruptible input plugin"
+
+    it "should connect and disconnect" do
+      instance.register
+      t = Thread.new { instance.run(Queue.new) }
+      sleep 5
+      expect(client).to have_received(:connect)
+      instance.do_stop
+      expect(client).to have_received(:disconnect)
+      t.join
+    end
   end
 end


### PR DESCRIPTION
This patch moves the connect call from register to run. It also makes connections interruptible during stop preventing this plugin from blocking the whole pipeline